### PR TITLE
feat: Add Nix package support and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: ci
 
 on:
@@ -13,17 +14,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: cachix/install-nix-action@v31
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
 
-    - uses: cachix/cachix-action@v16
-      with:
-        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        name: ${{ env.CACHIX_BINARY_CACHE }}
+      - uses: cachix/cachix-action@v16
+        with:
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          name: ${{ env.CACHIX_BINARY_CACHE }}
 
-    - run: nix develop -c make lint
+      - run: nix develop -c make lint
 
-    - run: nix develop -c make test
+      - run: nix develop -c make test
+
+      - run: nix build

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,23 @@
         system,
         ...
       }: {
+        packages.notion-nvim = pkgs.vimUtils.buildVimPlugin {
+          dependencies = with pkgs.vimPlugins; [plenary-nvim];
+          pname = "notion-nvim";
+          version = "unstable";
+          src = ./.;
+
+          meta = with pkgs.lib; {
+            description = "Neovim plugin for Notion integration";
+            homepage = "https://github.com/ALT-F4-LLC/notion.nvim";
+            license = licenses.asl20;
+            maintainers = [];
+            platforms = platforms.all;
+          };
+        };
+
+        packages.default = self'.packages.notion-nvim;
+
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             entr
@@ -27,6 +44,7 @@
             lua54Packages.luacov
             luajit
             luarocks
+            yamllint
           ];
 
           shellHook = ''


### PR DESCRIPTION
## Summary
- Added Nix flake support for building notion.nvim as a vim plugin package
- Updated GitHub Actions workflow to test Nix builds
- Fixed Apache 2.0 license specification in flake metadata
- Added yamllint to development environment

## Changes
- **flake.nix**: Added `packages.notion-nvim` using `buildVimPlugin` with plenary-nvim dependency
- **.github/workflows/ci.yml**: Added `nix build` step to CI pipeline and fixed YAML formatting
- **Development tools**: Added yamllint for YAML validation

## Test plan
- [x] Nix build succeeds locally (`nix build`)
- [x] Plugin dependencies correctly resolved (plenary-nvim)
- [x] CI workflow validates with yamllint
- [x] GitHub Actions workflow runs successfully with new Nix build step