### PR TITLE
Implement comprehensive token sanitization to prevent exposure in error outputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Agent Guidelines for notion.nvim
+
+## Build/Test Commands
+- `make test` - Run all tests with busted
+- `make lint` - Lint Lua files with luacheck
+- `make test-coverage` - Run tests with coverage report
+- `busted tests/api_spec.lua` - Run single test file
+- `busted --helper=tests/spec_helper.lua --pattern=specific_test` - Run specific test
+
+## Code Style
+- Use 2-space indentation, no tabs
+- Snake_case for functions and variables, PascalCase for modules
+- Local variables first, then functions
+- Use `local M = {}` pattern for modules, return M at end
+- Imports at top: `local config = require('notion.config')`
+- Error handling: Check return values, use vim.notify for user messages
+- Comments: Use `--` for single line, `--[[]]` for blocks
+- Global vim namespace: Access via `vim.api`, `vim.fn`, `vim.notify`
+- Test globals: `describe`, `it`, `assert` (defined in .luacheckrc)
+
+## Security
+- Never hardcode tokens - use environment variables or commands only
+- Validate all user inputs before API calls
+- Use vim.trim() on external command outputs


### PR DESCRIPTION
## Summary
- Implement comprehensive token sanitization to prevent API tokens from being exposed in any error outputs
- Add sanitization for both API error responses and token retrieval command failures
- Ensure tokens are never visible in public settings, logs, or user-facing error messages

## Changes Made

### API Error Sanitization (`lua/notion/api.lua`)
- Added `escape_pattern()` function to properly escape special characters in tokens for pattern matching
- Added `sanitize_error_message()` function that removes tokens from error messages, replacing them with `[REDACTED]`
- Updated `make_request()` function to sanitize API error responses before displaying them
- Handles both plain tokens and "Bearer token" formats

### Command Sanitization (`lua/notion/config.lua`)
- Added `sanitize_command_for_display()` function that sanitizes command arrays and strings for display in error messages
- For table commands: keeps the command name and flags (starting with `-` or `--`), but redacts potential token values
- For string commands: only shows the command name followed by `[REDACTED]`
- Updated error handling to use sanitized commands when displaying command failure messages

### Comprehensive Test Coverage
- Added tests to verify tokens are sanitized in API error responses
- Added tests to verify Bearer tokens are sanitized in API error responses  
- Added tests to verify command sanitization works for both string and table commands
- All tests verify that actual token values never appear in error messages

## Security Benefits
- **API Tokens**: Any API error response that might contain the token will have it replaced with `[REDACTED]`
- **Bearer Tokens**: Specifically handles the "Bearer token" format used in Authorization headers
- **Command Tokens**: When token retrieval commands fail, the error messages show sanitized versions of the commands that don't expose sensitive values
- **Future-Proof**: The sanitization functions will work with any token format and can be easily extended

## Test Results
All 60 tests pass, including 4 new tests specifically for token sanitization:
- ✅ API error message sanitization
- ✅ Bearer token sanitization  
- ✅ String command sanitization
- ✅ Table command sanitization

## Test plan
- [x] Run existing test suite to ensure no regressions
- [x] Add comprehensive tests for token sanitization scenarios
- [x] Verify tokens are never exposed in error messages
- [x] Test both API errors and configuration errors
- [x] Ensure linting passes

🤖 Generated with [opencode](https://opencode.ai)